### PR TITLE
Details feature

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="c6304664-9f9f-4ec2-a987-ce408830eb69" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/public/styles/daan.css" beforeDir="false" afterPath="$PROJECT_DIR$/public/styles/daan.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/views/personal-page.ejs" beforeDir="false" afterPath="$PROJECT_DIR$/views/personal-page.ejs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/public/daan-animations.js" beforeDir="false" afterPath="$PROJECT_DIR$/public/daan-animations.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -39,23 +37,23 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "ASKED_SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "git-widget-placeholder": "pop-up-feature",
-    "ignore.virus.scanning.warn.message": "true",
-    "last_opened_file_path": "C:/Users/daan/PhpstormProjects/pleasurable-ui-team-oba/public/img",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ASKED_SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;pop-up-feature&quot;,
+    &quot;ignore.virus.scanning.warn.message&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/Users/daan/PhpstormProjects/pleasurable-ui-team-oba/public/img&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="C:\Users\daan\PhpstormProjects\pleasurable-ui-team-oba\public\img" />
@@ -86,6 +84,7 @@
       <workItem from="1715719267931" duration="1472000" />
       <workItem from="1715758391285" duration="732000" />
       <workItem from="1715780406703" duration="1178000" />
+      <workItem from="1715858474267" duration="540000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,11 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="c6304664-9f9f-4ec2-a987-ce408830eb69" name="Changes" comment="" />
+    <list default="true" id="c6304664-9f9f-4ec2-a987-ce408830eb69" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/public/styles/daan.css" beforeDir="false" afterPath="$PROJECT_DIR$/public/styles/daan.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/views/personal-page.ejs" beforeDir="false" afterPath="$PROJECT_DIR$/views/personal-page.ejs" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -41,7 +45,7 @@
     "RunOnceActivity.OpenProjectViewOnStart": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "git-widget-placeholder": "Daan",
+    "git-widget-placeholder": "pop-up-feature",
     "ignore.virus.scanning.warn.message": "true",
     "last_opened_file_path": "C:/Users/daan/PhpstormProjects/pleasurable-ui-team-oba/public/img",
     "node.js.detected.package.eslint": "true",
@@ -64,7 +68,7 @@
   <component name="SharedIndexes">
     <attachedChunks>
       <set>
-        <option value="bundled-php-predefined-ba97393d7c68-b4dcf6bb9de9-com.jetbrains.php.sharedIndexes-PS-233.13135.108" />
+        <option value="bundled-php-predefined-ba97393d7c68-6f8e3395a2b4-com.jetbrains.php.sharedIndexes-PS-233.14808.18" />
       </set>
     </attachedChunks>
   </component>
@@ -81,6 +85,7 @@
       <workItem from="1715694951700" duration="5744000" />
       <workItem from="1715719267931" duration="1472000" />
       <workItem from="1715758391285" duration="732000" />
+      <workItem from="1715780406703" duration="1178000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="c6304664-9f9f-4ec2-a987-ce408830eb69" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/public/daan-animations.js" beforeDir="false" afterPath="$PROJECT_DIR$/public/daan-animations.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/public/styles/daan.css" beforeDir="false" afterPath="$PROJECT_DIR$/public/styles/daan.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/views/personal-page.ejs" beforeDir="false" afterPath="$PROJECT_DIR$/views/personal-page.ejs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -84,7 +87,7 @@
       <workItem from="1715719267931" duration="1472000" />
       <workItem from="1715758391285" duration="732000" />
       <workItem from="1715780406703" duration="1178000" />
-      <workItem from="1715858474267" duration="540000" />
+      <workItem from="1715858474267" duration="3291000" />
     </task>
     <servers />
   </component>

--- a/public/daan-animations.js
+++ b/public/daan-animations.js
@@ -20,13 +20,20 @@ const forYouTimeline = gsap.timeline({defaults: { duration: 1 }});
 // .from('.for-you-details', {duration: 0.7, y: '100%', ease: 'ease-in', delay: 0.1});
 
 
-// selecteer de button
-const forYouDetailsButton = document.getElementById('forYoudetails');
+// detail buttons
+const forYouDetailsButton = document.getElementById('forYoudetailsButton');
+const favoritesDetailsButton = document.getElementById('favoritesButton');
+const borrowedBooksDetailsButton = document.getElementById('borrowedBooksButton');
+
+// elementen voor de detail functie
 const forYouDetails = document.querySelector('.for-you-details');
+const favoritesDetails = document.querySelector('.favorites-details');
+const borrowedBooksDetails = document.querySelector('.borrowed-books-details');
 const contentWrapperActive = document.querySelector('.content-wrapper');
 const pageText = document.querySelector('.page');
 
-
+// click events
+// for you
 forYouDetailsButton.addEventListener('click', () => {
     // Zorg ervoor dat de animaties in de timeline 3x zo snel gaan
     carouselTimeline.timeScale(2);
@@ -38,14 +45,52 @@ forYouDetailsButton.addEventListener('click', () => {
     });
 });
 
+// favorites
+favoritesDetailsButton.addEventListener('click', () => {
+    // Zorg ervoor dat de animaties in de timeline 3x zo snel gaan
+    carouselTimeline.timeScale(2);
+
+    // Reverse de animatie op de timeline met .reverse
+    carouselTimeline.reverse().eventCallback("onReverseComplete", () => {
+        detailsFavoritesActive()
+        activeContentWrapper();
+    });
+});
+
+// borrowed books
+borrowedBooksDetailsButton.addEventListener('click', () => {
+    // Zorg ervoor dat de animaties in de timeline 3x zo snel gaan
+    carouselTimeline.timeScale(2);
+
+    // Reverse de animatie op de timeline met .reverse
+    carouselTimeline.reverse().eventCallback("onReverseComplete", () => {
+        detailsBorrowedBooksActive();
+        activeContentWrapper();
+    });
+});
+
+
+// details active functions
+
+// for you
 function detailsForYouActive(){
     forYouDetails.classList.add('for-you-details-active');
-    forYouDetails.classList.remove('for-you-details');
-    contentWrapperActive.classList.add('content-wrapper-active');
     pageText.innerHTML = 'Voor Jou'
-    console.log('ik werk');
 }
 
+//favorites
+function detailsFavoritesActive(){
+    favoritesDetails.classList.add('favorites-details-active');
+    pageText.innerHTML = 'Favorieten'
+}
+
+// borrowed books
+function detailsBorrowedBooksActive(){
+    borrowedBooksDetails.classList.add('borrowed-books-details-active');
+    pageText.innerHTML = 'Geleende Boeken'
+}
+
+// content wrapper
 function activeContentWrapper(){
     contentWrapperActive.classList.add('content-wrapper-active');
     console.log('wrapper');

--- a/public/daan-animations.js
+++ b/public/daan-animations.js
@@ -1,46 +1,49 @@
 // personal page load animations
-gsap.from('main', {duration: 0.7, y: '100%', ease: 'ease-in'})
-gsap.from('h1', {duration: 0.6, y: '100%', delay: 0.7, ease: 'ease-out'})
-gsap.from('.hamburger-menu', {duration: 0.5, y: '-150%', delay: 0.7, ease: 'bounce'})
-gsap.from('.oba-logo', {duration: 0.8, y: '-130%', delay: 0.7, ease: 'bounce'})
+gsap.from('main', {duration: 0.7, y: '100%', ease: 'ease-in'});
+gsap.from('h1', {duration: 0.6, y: '100%', delay: 0.7, ease: 'ease-out'});
+gsap.from('.hamburger-menu', {duration: 0.5, y: '-150%', delay: 0.7, ease: 'bounce'});
+gsap.from('.oba-logo', {duration: 0.8, y: '-130%', delay: 0.7, ease: 'bounce'});
 
 
 // timeline for the carousel animation
-const carouselTimeline = gsap.timeline({defaults: { duration: 1 }})
+const carouselTimeline = gsap.timeline({defaults: { duration: 1 }});
 
 carouselTimeline
     .from('.for-you', {duration: 0.5, x: '-100%', delay: 0.7, ease: 'ease-in'})
     .from('.favourites', {duration: 0.5, x: '100%', ease: 'ease-in'})
-    .from('.borrowed', {duration: 0.5, x: '-100%', ease: 'ease-in'})
+    .from('.borrowed', {duration: 0.5, x: '-100%', ease: 'ease-in'});
 
+// timeline for for you
+const forYouTimeline = gsap.timeline({defaults: { duration: 1 }});
 
-
-
+// forYouTimeline
+// .from('.for-you-details', {duration: 0.7, y: '100%', ease: 'ease-in', delay: 0.1});
 
 
 // selecteer de button
-const forYouDetailsButton = document.getElementById('forYoudetails')
-const forYouDetails = document.querySelector('.for-you-details')
-const contentWrapperActive = document.querySelector('.content-wrapper')
+const forYouDetailsButton = document.getElementById('forYoudetails');
+const forYouDetails = document.querySelector('.for-you-details');
+const contentWrapperActive = document.querySelector('.content-wrapper');
 
-// zet er een click event op en selecteer het object timeline
 forYouDetailsButton.addEventListener('click', () => {
-    // zorgt ervoor dat de animaties in de timeline 3x zo snel gaan
-    carouselTimeline.timeScale(2)
-    // reverse de animatie op de timeline met .reverse
-    carouselTimeline.reverse()
+    // Zorg ervoor dat de animaties in de timeline 3x zo snel gaan
+    carouselTimeline.timeScale(2);
 
-    detailsForYouActive()
-})
+    // Reverse de animatie op de timeline met .reverse
+    carouselTimeline.reverse().eventCallback("onReverseComplete", () => {
+        detailsForYouActive();
+        activeContentWrapper();
+    });
+});
 
 function detailsForYouActive(){
-    forYouDetails.classList.add('for-you-details-active')
-    forYouDetails.classList.remove('for-you-details')
-    contentWrapperActive.classList.add('content-wrapper-active')
-    console.log('ik werk')
+    forYouDetails.classList.add('for-you-details-active');
+    forYouDetails.classList.remove('for-you-details');
+    contentWrapperActive.classList.add('content-wrapper-active');
+    console.log('ik werk');
 }
 
 function activeContentWrapper(){
-    contentWrapperActive.classList.add('content-wrapper-active')
-    console.log('wrapper')
+    contentWrapperActive.classList.add('content-wrapper-active');
+    console.log('wrapper');
 }

--- a/public/daan-animations.js
+++ b/public/daan-animations.js
@@ -20,10 +20,15 @@ const forYouTimeline = gsap.timeline({defaults: { duration: 1 }});
 // .from('.for-you-details', {duration: 0.7, y: '100%', ease: 'ease-in', delay: 0.1});
 
 
-// detail buttons
+// detail active buttons
 const forYouDetailsButton = document.getElementById('forYoudetailsButton');
 const favoritesDetailsButton = document.getElementById('favoritesButton');
 const borrowedBooksDetailsButton = document.getElementById('borrowedBooksButton');
+
+// detail deactive buttons
+const forYouDetailsCloseButton = document.getElementById('forYouDetailsCloseButton');
+const favoritesDetailsCloseButton = document.getElementById('favoritesCloseButton');
+const borrowedBooksDetailsCloseButton = document.getElementById('borrowedBooksCloseButton');
 
 // elementen voor de detail functie
 const forYouDetails = document.querySelector('.for-you-details');
@@ -33,6 +38,9 @@ const contentWrapperActive = document.querySelector('.content-wrapper');
 const pageText = document.querySelector('.page');
 
 // click events
+
+// voor details active
+
 // for you
 forYouDetailsButton.addEventListener('click', () => {
     // Zorg ervoor dat de animaties in de timeline 3x zo snel gaan
@@ -69,6 +77,29 @@ borrowedBooksDetailsButton.addEventListener('click', () => {
     });
 });
 
+// voor details deactive
+
+// for you
+forYouDetailsCloseButton.addEventListener('click', () => {
+    // Zorg ervoor dat de animaties in de timeline 3x zo snel gaan
+    console.log('ik ben geklikt')
+        detailsForYouDeactive();
+        activeContentWrapperDeactive();
+});
+
+// favorites
+favoritesDetailsCloseButton.addEventListener('click', () => {
+        detailsFavoritesDeactive();
+        activeContentWrapperDeactive();
+});
+
+// borrowed books
+borrowedBooksDetailsCloseButton.addEventListener('click', () => {
+        detailsBorrowedBooksDeactive();
+        activeContentWrapperDeactive();
+});
+
+
 
 // details active functions
 
@@ -81,18 +112,52 @@ function detailsForYouActive(){
 //favorites
 function detailsFavoritesActive(){
     favoritesDetails.classList.add('favorites-details-active');
-    pageText.innerHTML = 'Favorieten'
+    pageText.innerHTML = 'Favorieten';
 }
 
 // borrowed books
 function detailsBorrowedBooksActive(){
     borrowedBooksDetails.classList.add('borrowed-books-details-active');
-    pageText.innerHTML = 'Geleende Boeken'
+    pageText.innerHTML = 'Geleende Boeken';
 }
 
 // content wrapper
 function activeContentWrapper(){
     contentWrapperActive.classList.add('content-wrapper-active');
+    console.log('wrapper');
+}
+
+// details deactive functions
+
+// for you
+// for you
+function detailsForYouDeactive(){
+    forYouDetails.classList.remove('for-you-details-active');
+    pageText.innerHTML = 'Gebruikers Pagina';
+    carouselTimeline.play(); // Speel de timeline-animatie opnieuw af zonder omkeren
+    activeContentWrapperDeactive(); // Roep de functie aan om de content wrapper ook te deactiveren
+}
+
+
+//favorites
+function detailsFavoritesDeactive(){
+    favoritesDetails.classList.remove('favorites-details-active');
+    pageText.innerHTML = 'Gebruikers Pagina'
+    carouselTimeline.play(); // Speel de timeline-animatie opnieuw af zonder omkeren
+    activeContentWrapperDeactive(); // Roep de functie aan om de content wrapper ook te deactiveren
+}
+
+// borrowed books
+function detailsBorrowedBooksDeactive(){
+    borrowedBooksDetails.classList.remove('borrowed-books-details-active');
+    pageText.innerHTML = 'Gebruikers Pagina'
+    carouselTimeline.play(); // Speel de timeline-animatie opnieuw af zonder omkeren
+    activeContentWrapperDeactive(); // Roep de functie aan om de content wrapper ook te deactiveren
+}
+
+// content wrapper
+function activeContentWrapperDeactive(){
+    contentWrapperActive.classList.remove('content-wrapper-active');
     console.log('wrapper');
 }
 

--- a/public/daan-animations.js
+++ b/public/daan-animations.js
@@ -13,12 +13,34 @@ carouselTimeline
     .from('.favourites', {duration: 0.5, x: '100%', ease: 'ease-in'})
     .from('.borrowed', {duration: 0.5, x: '-100%', ease: 'ease-in'})
 
+
+
+
+
+
 // selecteer de button
 const forYouDetailsButton = document.getElementById('forYoudetails')
+const forYouDetails = document.querySelector('.for-you-details')
+const contentWrapperActive = document.querySelector('.content-wrapper')
+
 // zet er een click event op en selecteer het object timeline
 forYouDetailsButton.addEventListener('click', () => {
     // zorgt ervoor dat de animaties in de timeline 3x zo snel gaan
     carouselTimeline.timeScale(2)
     // reverse de animatie op de timeline met .reverse
     carouselTimeline.reverse()
+
+    detailsForYouActive()
 })
+
+function detailsForYouActive(){
+    forYouDetails.classList.add('for-you-details-active')
+    forYouDetails.classList.remove('for-you-details')
+    contentWrapperActive.classList.add('content-wrapper-active')
+    console.log('ik werk')
+}
+
+function activeContentWrapper(){
+    contentWrapperActive.classList.add('content-wrapper-active')
+    console.log('wrapper')
+}

--- a/public/daan-animations.js
+++ b/public/daan-animations.js
@@ -24,6 +24,8 @@ const forYouTimeline = gsap.timeline({defaults: { duration: 1 }});
 const forYouDetailsButton = document.getElementById('forYoudetails');
 const forYouDetails = document.querySelector('.for-you-details');
 const contentWrapperActive = document.querySelector('.content-wrapper');
+const pageText = document.querySelector('.page');
+
 
 forYouDetailsButton.addEventListener('click', () => {
     // Zorg ervoor dat de animaties in de timeline 3x zo snel gaan
@@ -40,6 +42,7 @@ function detailsForYouActive(){
     forYouDetails.classList.add('for-you-details-active');
     forYouDetails.classList.remove('for-you-details');
     contentWrapperActive.classList.add('content-wrapper-active');
+    pageText.innerHTML = 'Voor Jou'
     console.log('ik werk');
 }
 
@@ -47,3 +50,4 @@ function activeContentWrapper(){
     contentWrapperActive.classList.add('content-wrapper-active');
     console.log('wrapper');
 }
+

--- a/public/daan-animations.js
+++ b/public/daan-animations.js
@@ -3,8 +3,22 @@ gsap.from('main', {duration: 0.7, y: '100%', ease: 'ease-in'})
 gsap.from('h1', {duration: 0.6, y: '100%', delay: 0.7, ease: 'ease-out'})
 gsap.from('.hamburger-menu', {duration: 0.5, y: '-150%', delay: 0.7, ease: 'bounce'})
 gsap.from('.oba-logo', {duration: 0.8, y: '-130%', delay: 0.7, ease: 'bounce'})
-gsap.from('.for-you', {duration: 0.5, x: '-100%', delay: 0.7, ease: 'ease-in'})
-gsap.from('.favourites', {duration: 0.5, x: '100%', delay: 0.7, ease: 'ease-in'})
-gsap.from('.borrowed', {duration: 0.5, x: '-100%', delay: 0.7, ease: 'ease-in'})
 
 
+// timeline for the carousel animation
+const carouselTimeline = gsap.timeline({defaults: { duration: 1 }})
+
+carouselTimeline
+    .from('.for-you', {duration: 0.5, x: '-100%', delay: 0.7, ease: 'ease-in'})
+    .from('.favourites', {duration: 0.5, x: '100%', ease: 'ease-in'})
+    .from('.borrowed', {duration: 0.5, x: '-100%', ease: 'ease-in'})
+
+// selecteer de button
+const forYouDetailsButton = document.getElementById('forYoudetails')
+// zet er een click event op en selecteer het object timeline
+forYouDetailsButton.addEventListener('click', () => {
+    // zorgt ervoor dat de animaties in de timeline 3x zo snel gaan
+    carouselTimeline.timeScale(2)
+    // reverse de animatie op de timeline met .reverse
+    carouselTimeline.reverse()
+})

--- a/public/styles/daan.css
+++ b/public/styles/daan.css
@@ -91,6 +91,10 @@ h1::first-line {
     cursor: pointer;
 }
 
+.for-you-details {
+    display: none;
+}
+
 ul {
     display: flex;
     overflow-x: auto;

--- a/public/styles/daan.css
+++ b/public/styles/daan.css
@@ -134,12 +134,7 @@ h1::first-line {
 }
 
 .favorites-details-active {
-    display: grid;
-    place-items: center;
-    justify-content: center;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    grid-auto-rows: minmax(200px, auto); /* Vaste hoogte van 200px voor alle rijen */
-    grid-gap: 1em; /* Optioneel: voeg ruimte toe tussen de kolommen */
+    display: block;
 }
 
 .borrowed-books-details {
@@ -147,12 +142,7 @@ h1::first-line {
 }
 
 .borrowed-books-details-active {
-    display: grid;
-    place-items: center;
-    justify-content: center;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    grid-auto-rows: minmax(200px, auto); /* Vaste hoogte van 200px voor alle rijen */
-    grid-gap: 1em;
+    display: block;
 }
 
 ul {

--- a/public/styles/daan.css
+++ b/public/styles/daan.css
@@ -89,7 +89,7 @@ h1::first-line {
     padding-right: 1.5em;
 }
 
-.forYouDetails {
+.details-buttons {
     background: none;
     border: none;
     font-size: 1.5em;

--- a/public/styles/daan.css
+++ b/public/styles/daan.css
@@ -18,7 +18,7 @@ header {
     border: none;
     width: 5em;
     height: 5em;
-    border-radius:20%;
+    border-radius: 20%;
     cursor: pointer;
     margin-bottom: 1.5em;
     margin-left: 1.5em;
@@ -46,6 +46,7 @@ body {
     overflow-x: hidden;
     background-color: var(--primary-color);
 }
+
 main {
     display: flex;
     flex-direction: column;
@@ -58,7 +59,6 @@ main {
     width: 100vw;
     top: 8%;
 }
-
 
 
 .content-wrapper-active {
@@ -96,6 +96,7 @@ h1::first-line {
     cursor: pointer;
 }
 
+/*hidden details*/
 .for-you-details {
     display: none;
 }
@@ -110,73 +111,101 @@ h1::first-line {
 
 }
 
+.favorites-details {
+    display: none;
+}
+
+.favorites-details-active {
+    display: grid;
+    place-items: center;
+    justify-content: center;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    grid-auto-rows: minmax(200px, auto); /* Vaste hoogte van 200px voor alle rijen */
+    grid-gap: 1em; /* Optioneel: voeg ruimte toe tussen de kolommen */
+}
+
+.borrowed-books-details {
+    display: none;
+}
+
+.borrowed-books-details-active {
+    display: grid;
+    place-items: center;
+    justify-content: center;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    grid-auto-rows: minmax(200px, auto); /* Vaste hoogte van 200px voor alle rijen */
+    grid-gap: 1em;
+}
+
+
+
 ul {
-    list-style: none;
+   list-style: none;
 }
 
 .carousel {
-    display: flex;
-    overflow-x: auto;
-    scrollbar-width: auto;
-    width: 100vw;
-    scroll-snap-type: x mandatory;
+   display: flex;
+   overflow-x: auto;
+   scrollbar-width: auto;
+   width: 100vw;
+   scroll-snap-type: x mandatory;
 
 }
 
 .carousel-items {
-    list-style: none;
-    margin: 1em;
-    scroll-snap-align: center;
+   list-style: none;
+   margin: 1em;
+   scroll-snap-align: center;
 }
 
 .bookCarouselImg {
-    border-radius: 2em;
-    cursor: pointer;
-    box-shadow: 6px 10px 5px darkgrey;
+   border-radius: 2em;
+   cursor: pointer;
+   box-shadow: 6px 10px 5px darkgrey;
 }
 
 .bookCarouselImg:hover {
-    scale: 1.1;
-    transition: 0.1s ease-out;
-    box-shadow: 3px 6px 10px darkgrey;
+   scale: 1.1;
+   transition: 0.1s ease-out;
+   box-shadow: 3px 6px 10px darkgrey;
 
 }
 
 
 ::-webkit-scrollbar {
-    height: 0.9em;
-    width: 0.3em;
-    background: #B6B6B6;
-    border-radius: 2em;
-    box-shadow: 7px 10px 15px darkgrey;
+   height: 0.9em;
+   width: 0.3em;
+   background: #B6B6B6;
+   border-radius: 2em;
+   box-shadow: 7px 10px 15px darkgrey;
 }
 
 ::-webkit-scrollbar:hover {
-    scale: 1.2;
+   scale: 1.2;
 }
 
 ::-webkit-scrollbar-thumb:horizontal {
-    background: var(--primary-color);
-    border-radius: 2em;
-    width: 5em;
+   background: var(--primary-color);
+   border-radius: 2em;
+   width: 5em;
 }
 
 ::-webkit-scrollbar-thumb {
-    background: var(--primary-color);
-    width: 2em;
-    border-radius: 2em;
+   background: var(--primary-color);
+   width: 2em;
+   border-radius: 2em;
 }
 
 ::-webkit-scrollbar-button:end {
-    width: 0.5em;
+   width: 0.5em;
 }
 
 ::-webkit-scrollbar-button:start {
-    width: 0.5em;
+   width: 0.5em;
 }
 
 ::-webkit-scrollbar-button {
-    height: 1em;
+   height: 1em;
 }
 
 

--- a/public/styles/daan.css
+++ b/public/styles/daan.css
@@ -46,7 +46,6 @@ body {
     overflow-x: hidden;
     background-color: var(--primary-color);
 }
-
 main {
     display: flex;
     flex-direction: column;
@@ -58,6 +57,12 @@ main {
     position: absolute;
     width: 100vw;
     top: 8%;
+}
+
+
+
+.content-wrapper-active {
+    display: block;
 }
 
 .profile-picture {
@@ -95,7 +100,21 @@ h1::first-line {
     display: none;
 }
 
+.for-you-details-active {
+    display: grid;
+    place-items: center;
+    justify-content: center;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    grid-auto-rows: minmax(200px, auto); /* Vaste hoogte van 200px voor alle rijen */
+    grid-gap: 2em; /* Optioneel: voeg ruimte toe tussen de kolommen */
+
+}
+
 ul {
+    list-style: none;
+}
+
+.carousel {
     display: flex;
     overflow-x: auto;
     scrollbar-width: auto;
@@ -104,7 +123,7 @@ ul {
 
 }
 
-li {
+.carousel-items {
     list-style: none;
     margin: 1em;
     scroll-snap-align: center;

--- a/public/styles/daan.css
+++ b/public/styles/daan.css
@@ -97,17 +97,29 @@ h1::first-line {
 }
 
 /*hidden details*/
-.for-you-details {
-    display: none;
-}
 
-.for-you-details-active {
+.details-item-container {
     display: grid;
     place-items: center;
     justify-content: center;
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     grid-auto-rows: minmax(200px, auto); /* Vaste hoogte van 200px voor alle rijen */
     grid-gap: 1em; /* Optioneel: voeg ruimte toe tussen de kolommen */
+}
+
+.details-close-buttons {
+    position: relative;
+    left: 50%;
+    transform: translateX(-50%);
+    margin: 1em 0;
+}
+
+.for-you-details {
+    display: none;
+}
+
+.for-you-details-active {
+    display: block;
 
 }
 
@@ -136,8 +148,6 @@ h1::first-line {
     grid-auto-rows: minmax(200px, auto); /* Vaste hoogte van 200px voor alle rijen */
     grid-gap: 1em;
 }
-
-
 
 ul {
    list-style: none;

--- a/public/styles/daan.css
+++ b/public/styles/daan.css
@@ -112,6 +112,12 @@ h1::first-line {
     left: 50%;
     transform: translateX(-50%);
     margin: 1em 0;
+    background: none;
+    border: none;
+    font-size: 1.5em;
+    cursor: pointer;
+    color: var(--primary-color);
+    font-weight: bold;
 }
 
 .for-you-details {

--- a/public/styles/daan.css
+++ b/public/styles/daan.css
@@ -104,9 +104,9 @@ h1::first-line {
     display: grid;
     place-items: center;
     justify-content: center;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     grid-auto-rows: minmax(200px, auto); /* Vaste hoogte van 200px voor alle rijen */
-    grid-gap: 2em; /* Optioneel: voeg ruimte toe tussen de kolommen */
+    grid-gap: 1em; /* Optioneel: voeg ruimte toe tussen de kolommen */
 
 }
 

--- a/views/personal-page.ejs
+++ b/views/personal-page.ejs
@@ -81,7 +81,6 @@
 
         <div class="details">
             <h2>Voor Jou</h2>
-            <div class="details-container">
                 <button id="forYoudetailsButton">Details +</button>
             </div>
             <ul class="carousel">

--- a/views/personal-page.ejs
+++ b/views/personal-page.ejs
@@ -43,10 +43,22 @@
     <h1>Gebruiker's Pagina</h1>
     <!--Voor Jou-->
     <section class="for-you">
+
         <div class="details">
             <h2>Voor Jou</h2>
-            <button class="forYouDetails">Details +</button>
-        </div>
+            <div class="details-container">
+
+                <button id="forYoudetails">Details +</button>
+
+                <ul class="for-you-details">
+                    <% apiItems.forEach(function(apiItem) { %>
+                        <li>
+                            <img class="bookCarouselImg" src='https://fdnd-agency.directus.app/assets/<%= apiItem.afbeelding %>'
+                                 alt="<%= apiItem.title %>" width="200" height="300">
+                        </li>
+                    <% }) %>
+                </ul>
+            </div>
         <ul class="bookCarousel">
             <% apiItems.forEach(function(apiItem) { %>
                 <li>

--- a/views/personal-page.ejs
+++ b/views/personal-page.ejs
@@ -41,7 +41,7 @@
 <main>
 
     <img class="profile-picture" src="/img/profile-picture.jpg" alt="profiel foto" width="190" height="190">
-    <h1>Gebruiker's Pagina</h1>
+    <h1 class="page">Gebruiker's Pagina</h1>
     <!--Voor Jou-->
 
     <section class="content-wrapper">

--- a/views/personal-page.ejs
+++ b/views/personal-page.ejs
@@ -90,7 +90,7 @@
 
         <div class="details">
             <h2>Voor Jou</h2>
-                <button id="forYoudetailsButton">Details +</button>
+                <button class="details-buttons" id="forYoudetailsButton">Details +</button>
             </div>
             <ul class="carousel">
                 <% apiItems.forEach(function(apiItem) { %>
@@ -106,7 +106,7 @@
     <section class="favourites">
         <div class="details">
             <h2>Favorieten</h2>
-            <button id="favoritesButton">Details +</button>
+            <button class="details-buttons" id="favoritesButton">Details +</button>
         </div>
         <ul class="carousel">
             <% apiItems.forEach(function(apiItem) { %>
@@ -121,7 +121,7 @@
     <section class="borrowed">
         <div class="details">
             <h2>Geleende Boeken</h2>
-            <button id="borrowedBooksButton">Details +</button>
+            <button class="details-buttons" id="borrowedBooksButton">Details +</button>
         </div>
         <ul class="carousel">
             <% apiItems.forEach(function(apiItem) { %>

--- a/views/personal-page.ejs
+++ b/views/personal-page.ejs
@@ -48,7 +48,7 @@
 
 <!--for you details (hidden)-->
         <div class="for-you-details">
-            <button class="details-close-buttons" id="forYouDetailsHiddenButton">Details Sluiten</button>
+            <button class="details-close-buttons" id="forYouDetailsCloseButton">Details Sluiten</button>
             <section class="details-item-container">
         <% apiItems.forEach(function(apiItem) { %>
 
@@ -56,12 +56,12 @@
                      alt="<%= apiItem.title %>" width="200" height="300">
 
         <% }) %>
-            <section class="details-item-container">
+            </section>
     </div>
 
         <!--favorites details (hidden)-->
         <div class="favorites-details">
-            <button class="details-close-buttons" id="favoritesHiddenButton">Details Sluiten</button>
+            <button class="details-close-buttons" id="favoritesCloseButton">Details Sluiten</button>
             <section class="details-item-container">
             <% apiItems.forEach(function(apiItem) { %>
 
@@ -74,7 +74,7 @@
 
         <!--borrowed books details (hidden)-->
         <div class="borrowed-books-details">
-            <button class="details-close-buttons" id="borrowedBooksHiddenButton">Details Sluiten</button>
+            <button class="details-close-buttons" id="borrowedBooksCloseButton">Details Sluiten</button>
             <section class="details-item-container">
             <% apiItems.forEach(function(apiItem) { %>
 

--- a/views/personal-page.ejs
+++ b/views/personal-page.ejs
@@ -39,34 +39,38 @@
     <img src="/img/OBA_wit.png" alt="oba logo" class="oba-logo" width="110" height="70">
 </header>
 <main>
+
     <img class="profile-picture" src="/img/profile-picture.jpg" alt="profiel foto" width="190" height="190">
     <h1>Gebruiker's Pagina</h1>
     <!--Voor Jou-->
+
+    <section class="content-wrapper">
+    <div class="for-you-details">
+        <% apiItems.forEach(function(apiItem) { %>
+
+                <img class="bookCarouselImg" src='https://fdnd-agency.directus.app/assets/<%= apiItem.afbeelding %>'
+                     alt="<%= apiItem.title %>" width="200" height="300">
+
+        <% }) %>
+    </div>
+
+
     <section class="for-you">
 
         <div class="details">
             <h2>Voor Jou</h2>
             <div class="details-container">
-
                 <button id="forYoudetails">Details +</button>
-
-                <ul class="for-you-details">
-                    <% apiItems.forEach(function(apiItem) { %>
-                        <li>
-                            <img class="bookCarouselImg" src='https://fdnd-agency.directus.app/assets/<%= apiItem.afbeelding %>'
-                                 alt="<%= apiItem.title %>" width="200" height="300">
-                        </li>
-                    <% }) %>
-                </ul>
             </div>
-        <ul class="bookCarousel">
-            <% apiItems.forEach(function(apiItem) { %>
-                <li>
-                    <img class="bookCarouselImg" src='https://fdnd-agency.directus.app/assets/<%= apiItem.afbeelding %>'
-                         alt="<%= apiItem.title %>" width="200" height="300">
-                </li>
-            <% }) %>
-        </ul>
+            <ul class="carousel">
+                <% apiItems.forEach(function(apiItem) { %>
+                    <li class="carousel-items">
+                        <img class="bookCarouselImg"
+                             src='https://fdnd-agency.directus.app/assets/<%= apiItem.afbeelding %>'
+                             alt="<%= apiItem.title %>" width="200" height="300">
+                    </li>
+                <% }) %>
+            </ul>
     </section>
 
     <section class="favourites">
@@ -74,9 +78,9 @@
             <h2>Favorieten</h2>
             <button class="forYouDetails">Details +</button>
         </div>
-        <ul class="bookCarousel">
+        <ul class="carousel">
             <% apiItems.forEach(function(apiItem) { %>
-                <li>
+                <li class="carousel-items">
                     <img class="bookCarouselImg" src='https://fdnd-agency.directus.app/assets/<%= apiItem.afbeelding %>'
                          alt="<%= apiItem.title %>" width="200" height="300">
                 </li>
@@ -89,15 +93,19 @@
             <h2>Geleende Boeken</h2>
             <button class="forYouDetails">Details +</button>
         </div>
-        <ul class="bookCarousel">
+        <ul class="carousel">
             <% apiItems.forEach(function(apiItem) { %>
-                <li>
+                <li class="carousel-items">
                     <img class="bookCarouselImg" src='https://fdnd-agency.directus.app/assets/<%= apiItem.afbeelding %>'
                          alt="<%= apiItem.title %>" width="200" height="300">
                 </li>
             <% }) %>
         </ul>
     </section>
+
+    </section>
+
+
 
 
 

--- a/views/personal-page.ejs
+++ b/views/personal-page.ejs
@@ -48,32 +48,41 @@
 
 <!--for you details (hidden)-->
         <div class="for-you-details">
+            <button class="details-close-buttons" id="forYouDetailsHiddenButton">Details Sluiten</button>
+            <section class="details-item-container">
         <% apiItems.forEach(function(apiItem) { %>
 
                 <img class="bookCarouselImg" src='https://fdnd-agency.directus.app/assets/<%= apiItem.afbeelding %>'
                      alt="<%= apiItem.title %>" width="200" height="300">
 
         <% }) %>
+            <section class="details-item-container">
     </div>
 
         <!--favorites details (hidden)-->
         <div class="favorites-details">
+            <button class="details-close-buttons" id="favoritesHiddenButton">Details Sluiten</button>
+            <section class="details-item-container">
             <% apiItems.forEach(function(apiItem) { %>
 
                 <img class="bookCarouselImg" src='https://fdnd-agency.directus.app/assets/<%= apiItem.afbeelding %>'
                      alt="<%= apiItem.title %>" width="200" height="300">
 
             <% }) %>
+            </section>
         </div>
 
         <!--borrowed books details (hidden)-->
         <div class="borrowed-books-details">
+            <button class="details-close-buttons" id="borrowedBooksHiddenButton">Details Sluiten</button>
+            <section class="details-item-container">
             <% apiItems.forEach(function(apiItem) { %>
 
                 <img class="bookCarouselImg" src='https://fdnd-agency.directus.app/assets/<%= apiItem.afbeelding %>'
                      alt="<%= apiItem.title %>" width="200" height="300">
 
             <% }) %>
+            </section>
         </div>
 
 <!--main page content-->

--- a/views/personal-page.ejs
+++ b/views/personal-page.ejs
@@ -82,7 +82,7 @@
         <div class="details">
             <h2>Voor Jou</h2>
             <div class="details-container">
-                <button id="forYoudetails">Details +</button>
+                <button id="forYoudetailsButton">Details +</button>
             </div>
             <ul class="carousel">
                 <% apiItems.forEach(function(apiItem) { %>

--- a/views/personal-page.ejs
+++ b/views/personal-page.ejs
@@ -45,7 +45,8 @@
     <!--Voor Jou-->
 
     <section class="content-wrapper">
-    <div class="for-you-details">
+
+        <div class="for-you-details">
         <% apiItems.forEach(function(apiItem) { %>
 
                 <img class="bookCarouselImg" src='https://fdnd-agency.directus.app/assets/<%= apiItem.afbeelding %>'

--- a/views/personal-page.ejs
+++ b/views/personal-page.ejs
@@ -46,6 +46,7 @@
 
     <section class="content-wrapper">
 
+<!--for you details (hidden)-->
         <div class="for-you-details">
         <% apiItems.forEach(function(apiItem) { %>
 
@@ -55,7 +56,27 @@
         <% }) %>
     </div>
 
+        <!--favorites details (hidden)-->
+        <div class="favorites-details">
+            <% apiItems.forEach(function(apiItem) { %>
 
+                <img class="bookCarouselImg" src='https://fdnd-agency.directus.app/assets/<%= apiItem.afbeelding %>'
+                     alt="<%= apiItem.title %>" width="200" height="300">
+
+            <% }) %>
+        </div>
+
+        <!--borrowed books details (hidden)-->
+        <div class="borrowed-books-details">
+            <% apiItems.forEach(function(apiItem) { %>
+
+                <img class="bookCarouselImg" src='https://fdnd-agency.directus.app/assets/<%= apiItem.afbeelding %>'
+                     alt="<%= apiItem.title %>" width="200" height="300">
+
+            <% }) %>
+        </div>
+
+<!--main page content-->
     <section class="for-you">
 
         <div class="details">
@@ -77,7 +98,7 @@
     <section class="favourites">
         <div class="details">
             <h2>Favorieten</h2>
-            <button class="forYouDetails">Details +</button>
+            <button id="favoritesButton">Details +</button>
         </div>
         <ul class="carousel">
             <% apiItems.forEach(function(apiItem) { %>
@@ -92,7 +113,7 @@
     <section class="borrowed">
         <div class="details">
             <h2>Geleende Boeken</h2>
-            <button class="forYouDetails">Details +</button>
+            <button id="borrowedBooksButton">Details +</button>
         </div>
         <ul class="carousel">
             <% apiItems.forEach(function(apiItem) { %>


### PR DESCRIPTION
## Wat heb ik gemaakt?

Ik heb een feature gemaakt die ervoor zorgt dat de items van het carousel: voor jou, favorieten en geleende boeken appart opgevraagd kunnen worden via de knop details +. fixes#8

Wanneer hier op gedrukt wordt worden de items in de hele pagina in een grid layout weergegeven, dit met de reden dat: 
- alle content makkelijker te overzien is
- hier later eventuele filters op toegepast kunnen worden
-  er een limiet aan boeken in de carousel gezet worden wanneer de carousel te lang wordt.

Dit is hoe de functie werkt.

1. Druk op de details knop boven het carousel waar jij alle items van wilt zien
![image](https://github.com/fdnd-task/pleasurable-ui/assets/54812898/dc0bced1-3283-4e67-b9c4-79aeac605c64)

2. Je ziet nu alle items in een bredere grid view
![image](https://github.com/fdnd-task/pleasurable-ui/assets/54812898/cf9c62fc-a23c-4ef0-9181-11d3cb4f8a57)

3. Als je weer terug wilt druk op details sluiten
![image](https://github.com/fdnd-task/pleasurable-ui/assets/54812898/7853c0af-9d3a-4e5b-a6a8-3d09fbc13163)

## Wat is er veranderd in de code?

### personal-page.ejs
Hierin heb ik 3 content blokken gemaakt die op hidden staan. Deze worden weergegeven wanneer je op Details klikt.

## CSS
Hierin heb ik detail deactive en active classes aangemaakt zodat de grid views ontzichtbaar en zichtbaar kunnen worden.

## JS
Ik heb de animatie van de carousels in een gsap timeline gezet zodat deze gereversed kan worden wanneer je op de knop drukt. Ook heb ik hierin active en deactive functies aangemaakt zodat de uitgebreide item grid view verborgen of weer teruggehaald kan worden. 


## Design
Dit is het figma design wat ik van te voren heb aangeleverd, dit kan gebruikt worden als vergelijkingsmateriaal. [Figma Design](https://www.figma.com/design/UauL5iuk8OG0cpGK6JJg3P/OBA-Profile-Page-Design?node-id=0%3A1&t=uxAza1ByurPDITcj-1)


